### PR TITLE
[WIP] Make the live TCP server more like we want

### DIFF
--- a/src/online2bin/Makefile
+++ b/src/online2bin/Makefile
@@ -25,5 +25,5 @@ ADDLIBS = ../online2/kaldi-online2.a ../ivector/kaldi-ivector.a \
           ../lat/kaldi-lat.a ../fstext/kaldi-fstext.a ../hmm/kaldi-hmm.a \
           ../feat/kaldi-feat.a ../transform/kaldi-transform.a \
           ../gmm/kaldi-gmm.a ../tree/kaldi-tree.a ../util/kaldi-util.a \
-          ../matrix/kaldi-matrix.a ../base/kaldi-base.a
+          ../matrix/kaldi-matrix.a ../base/kaldi-base.a ../lm/kaldi-lm.a
 include ../makefiles/default_rules.mk

--- a/src/online2bin/Makefile
+++ b/src/online2bin/Makefile
@@ -5,6 +5,7 @@ include ../kaldi.mk
 
 LDFLAGS += $(CUDA_LDFLAGS)
 LDLIBS += $(CUDA_LDLIBS)
+LDLIBS += -ljansson
 
 BINFILES = online2-wav-gmm-latgen-faster apply-cmvn-online \
      extend-wav-with-silence compress-uncompress-speex \
@@ -24,5 +25,5 @@ ADDLIBS = ../online2/kaldi-online2.a ../ivector/kaldi-ivector.a \
           ../lat/kaldi-lat.a ../fstext/kaldi-fstext.a ../hmm/kaldi-hmm.a \
           ../feat/kaldi-feat.a ../transform/kaldi-transform.a \
           ../gmm/kaldi-gmm.a ../tree/kaldi-tree.a ../util/kaldi-util.a \
-          ../matrix/kaldi-matrix.a ../base/kaldi-base.a 
+          ../matrix/kaldi-matrix.a ../base/kaldi-base.a
 include ../makefiles/default_rules.mk

--- a/src/online2bin/online2-tcp-nnet3-decode-faster.cc
+++ b/src/online2bin/online2-tcp-nnet3-decode-faster.cc
@@ -257,7 +257,7 @@ std::string LatticeToJson(const Lattice &lat,
                           const ConstArpaLm &carpa) {
   Lattice tmp_lat(lat), composed_lat;
 
-  CompactLattice determinized_lat, composed_clat, res_lat;
+  CompactLattice determinized_lat, composed_clat, res_clat;
 
   fst::ScaleLattice(fst::GraphLatticeScale(-1.0), &tmp_lat);
   ArcSort(&tmp_lat, fst::OLabelCompare<LatticeArc>());
@@ -278,15 +278,15 @@ std::string LatticeToJson(const Lattice &lat,
   ComposeCompactLatticeDeterministic(determinized_lat, &const_arpa_fst, &composed_clat);
   ConvertLattice(composed_clat, &composed_lat);
   Invert(&composed_lat);
-  DeterminizeLattice(composed_lat, &res_lat);
-  fst::ScaleLattice(fst::GraphLatticeScale(1.0), &res_lat);
+  DeterminizeLattice(composed_lat, &res_clat);
+  fst::ScaleLattice(fst::GraphLatticeScale(1.0), &res_clat);
 
-  if (res_lat.Start() == fst::kNoStateId) {
+  if (res_clat.Start() == fst::kNoStateId) {
     KALDI_WARN << "Empty lattice (incompatible LM?)";
     return "";
   }
 
-  return LatticeToJson(res_lat, word_syms, word_boundary, trans_model,
+  return LatticeToJson(res_clat, word_syms, word_boundary, trans_model,
                        feature_info, decodable_opts, frame_offset, final);
 }
 
@@ -306,10 +306,10 @@ std::string LatticeToJson(const CompactLattice &clat,
     return "";
   }
 
-  Lattice best_path_lat;
-  ConvertLattice(clat, &best_path_lat);
+  Lattice lat;
+  ConvertLattice(clat, &lat);
 
-  return LatticeToJson(best_path_lat, word_syms, word_boundary, trans_model,
+  return LatticeToJson(lat, word_syms, word_boundary, trans_model,
                        feature_info, decodable_opts, frame_offset, final,
                        lm_fst, lm_compose_cache, carpa);
 }

--- a/src/online2bin/online2-tcp-nnet3-decode-faster.cc
+++ b/src/online2bin/online2-tcp-nnet3-decode-faster.cc
@@ -287,16 +287,18 @@ std::string LatticeToJson(const Lattice &lat,
     return "";
   }
 
-  BaseFloat acoustic_scale = 1.0 / lmwt;
-  fst::ScaleLattice(fst::AcousticLatticeScale(acoustic_scale), &res_clat);
+  if (lmwt != 1.0) {
+    BaseFloat acoustic_scale = 1.0 / lmwt;
+    fst::ScaleLattice(fst::AcousticLatticeScale(acoustic_scale), &res_clat);
 
-  if (!PruneLattice(5.0, &res_clat)) {
-    KALDI_WARN << "Error pruning lattice";
-    return "";
+    if (!PruneLattice(5.0, &res_clat)) {
+      KALDI_WARN << "Error pruning lattice";
+      return "";
+    }
+
+    fst::ScaleLattice(fst::AcousticLatticeScale(1.0/acoustic_scale), &res_clat);
   }
-
-  fst::ScaleLattice(fst::AcousticLatticeScale(1.0/acoustic_scale), &res_clat);
-
+  
   return LatticeToJson(res_clat, word_syms, word_boundary, trans_model,
                        feature_info, decodable_opts, frame_offset, final);
 }
@@ -360,7 +362,7 @@ int main(int argc, char *argv[]) {
     int port_num = 5050;
     int read_timeout = 3;
     bool rescore = false;
-    int lmwt = 10;
+    BaseFloat lmwt = 1.0;
 
     po.Register("samp-freq", &samp_freq,
                 "Sampling frequency of the input signal (coded as 16-bit slinear).");

--- a/src/online2bin/online2-tcp-nnet3-decode-faster.cc
+++ b/src/online2bin/online2-tcp-nnet3-decode-faster.cc
@@ -114,7 +114,7 @@ std::string LatticeToJson(const Lattice &lat,
   }
   std::string transcript = tr.str();
   size_t end = transcript.find_last_not_of(" \n\r\t\f\v");
-	transcript = (end == std::string::npos) ? "" : transcript.substr(0, end + 1);
+  transcript = (end == std::string::npos) ? "" : transcript.substr(0, end + 1);
 
   // Break here if we have no words, this skips the segment totally
   if (transcript.empty())

--- a/src/online2bin/online2-tcp-nnet3-decode-faster.cc
+++ b/src/online2bin/online2-tcp-nnet3-decode-faster.cc
@@ -201,6 +201,7 @@ std::string LatticeToJson(const Lattice &lat,
   json_t *result_json_object = json_object();
   json_object_set_new(root, "status", json_integer(0));
   json_object_set_new(root, "result", result_json_object);
+
   if (final)
     json_object_set_new(result_json_object, "final", json_true());
   else
@@ -212,8 +213,8 @@ std::string LatticeToJson(const Lattice &lat,
   json_object_set_new(root, "segment-start",  json_real((frame_offset - num_frames) * frame_shift));
   json_object_set_new(root, "segment-length",  json_real(num_frames * frame_shift));
   json_object_set_new(root, "total-length",  json_real(frame_offset * frame_shift));
-  json_t *nbest_json_arr = json_array();
 
+  json_t *nbest_json_arr = json_array();
   json_t *nbest_result_json_object = json_object();
   json_object_set_new(nbest_result_json_object, "transcript", json_string(transcript.c_str()));
   json_object_set_new(nbest_result_json_object, "likelihood",  json_real(likelihood));

--- a/src/online2bin/online2-tcp-nnet3-decode-faster.cc
+++ b/src/online2bin/online2-tcp-nnet3-decode-faster.cc
@@ -407,7 +407,6 @@ int main(int argc, char *argv[]) {
             if (decoder.NumFramesDecoded() > 0) {
               CompactLattice lat;
               decoder.GetLattice(true, &lat);
-              //std::string msg = LatticeToString(lat, *word_syms);
               std::string msg = LatticeToJson(lat, *word_syms, *word_boundary, trans_model,
                                               feature_info, decodable_opts, frame_offset, true);
               if (msg.size() > 0)
@@ -437,7 +436,6 @@ int main(int argc, char *argv[]) {
             if (decoder.NumFramesDecoded() > 0) {
               Lattice lat;
               decoder.GetBestPath(false, &lat);
-              //std::string msg = LatticeToString(lat, *word_syms);
               std::string msg = LatticeToJson(lat, *word_syms, *word_boundary, trans_model,
                                               feature_info, decodable_opts, 
                                               frame_offset + decoder.NumFramesDecoded(), false);
@@ -452,7 +450,6 @@ int main(int argc, char *argv[]) {
             frame_offset += decoder.NumFramesDecoded();
             CompactLattice lat;
             decoder.GetLattice(true, &lat);
-            //std::string msg = LatticeToString(lat, *word_syms);
             std::string msg = LatticeToJson(lat, *word_syms, *word_boundary, trans_model,
                                               feature_info, decodable_opts, frame_offset, true);
             if (msg.size() > 0)


### PR DESCRIPTION
Basically we need two things:
- JSON output
- rescoring

JSON output will need jansson as a dependency, not sure if we want this dep internally (within the kaldi build process) or externally, as an `apt install` in a docker image for instance.

BTW, I'm not 100% positive as if rescoring should be used in a voice bot context, or even in a live speech context, so I've made it optional (`--rescore=true`, `false` by default).

I've also added the capability to make the server configurable with only an Allo-Media model directory.

Also, I've added an option for LM weight, not used for now.